### PR TITLE
Remove TinyLlama from LFS and add caching mechanism

### DIFF
--- a/code/modules/chat/chat_model_loader.py
+++ b/code/modules/chat/chat_model_loader.py
@@ -32,7 +32,6 @@ class ChatModelLoader:
         elif self.config["llm_params"]["llm_loader"] == "local_llm":
             n_batch = 512  # Should be between 1 and n_ctx, consider the amount of VRAM in your GPU.
             model_path = self._verify_model_cache(self.config["llm_params"]["local_llm_params"]["model"])
-            print(model_path)
             llm = LlamaCpp(
                 model_path=model_path,
                 n_batch=n_batch,

--- a/code/modules/chat/chat_model_loader.py
+++ b/code/modules/chat/chat_model_loader.py
@@ -18,8 +18,8 @@ class ChatModelLoader:
 
     def _verify_model_cache(self, model_cache_path):
         hf_hub_download(
-            repo_id="TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF",
-            filename="tinyllama-1.1b-chat-v1.0.Q5_0.gguf",
+            repo_id=self.config["llm_params"]["local_llm_params"]["repo_id"],
+            filename=self.config["llm_params"]["local_llm_params"]["filename"],
             cache_dir=model_cache_path
             )
         return str(list(Path(model_cache_path).glob("*/snapshots/*/*.gguf"))[0])

--- a/code/modules/config/config.yml
+++ b/code/modules/config/config.yml
@@ -34,6 +34,7 @@ llm_params:
     temperature: 0.7
     repo_id: 'TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF' # HuggingFace repo id
     filename: 'tinyllama-1.1b-chat-v1.0.Q5_0.gguf' # Specific name of gguf file in the repo
+  pdf_reader: 'llama' # str [llama, pymupdf, gpt]
 
 chat_logging:
   log_chat: False # bool

--- a/code/modules/config/config.yml
+++ b/code/modules/config/config.yml
@@ -1,6 +1,6 @@
 log_dir: '../storage/logs' # str
 log_chunk_dir: '../storage/logs/chunks' # str
-device: 'cuda' # str [cuda, cpu]
+device: 'cpu' # str [cuda, cpu]
 
 vectorstore:
   load_from_HF: True # bool

--- a/code/modules/config/config.yml
+++ b/code/modules/config/config.yml
@@ -1,6 +1,6 @@
 log_dir: '../storage/logs' # str
 log_chunk_dir: '../storage/logs/chunks' # str
-device: 'cpu' # str [cuda, cpu]
+device: 'cuda' # str [cuda, cpu]
 
 vectorstore:
   embedd_files: False # bool
@@ -32,6 +32,8 @@ llm_params:
   local_llm_params:
     model: 'tiny-llama'
     temperature: 0.7
+    repo_id: 'TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF' # HuggingFace repo id
+    filename: 'tinyllama-1.1b-chat-v1.0.Q5_0.gguf' # Specific name of gguf file in the repo
 
 chat_logging:
   log_chat: False # bool

--- a/code/modules/config/constants.py
+++ b/code/modules/config/constants.py
@@ -78,5 +78,5 @@ Question: {question}
 
 # Model Paths
 
-LLAMA_PATH = "../storage/models/tinyllama-1.1b-chat-v1.0.Q5_K_M.gguf"
+LLAMA_PATH = "../storage/models/tinyllama"
 MISTRAL_PATH = "storage/models/mistral-7b-v0.1.Q4_K_M.gguf"

--- a/storage/models/tinyllama-1.1b-chat-v1.0.Q5_K_M.gguf
+++ b/storage/models/tinyllama-1.1b-chat-v1.0.Q5_K_M.gguf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aa54a5fb99ace5b964859cf072346631b2da6109715a805d07161d157c66ce7f
-size 783017344


### PR DESCRIPTION
Utilizes Hugging Face's ```huggingface_hub``` python package to cache the local llm model (TinyLlama in this case). The `repo_id` and `filename` are hard coded due to the `repo_id` not being a 1 to 1 match with anything we currently have.